### PR TITLE
Shading mode set to unshaded

### DIFF
--- a/rust_gdext/src/physics/gravity.rs
+++ b/rust_gdext/src/physics/gravity.rs
@@ -1,7 +1,7 @@
 use std::mem;
 
 use godot::{
-    classes::{ArrayMesh, Engine, MeshInstance3D, StandardMaterial3D, SurfaceTool, mesh},
+    classes::{base_material_3d::ShadingMode, mesh, ArrayMesh, Engine, MeshInstance3D, StandardMaterial3D, SurfaceTool},
     prelude::*,
 };
 use itertools::Itertools;
@@ -203,7 +203,7 @@ impl GravityController {
         // Create material with color
         let mut material = StandardMaterial3D::new_gd();
         material.set_albedo(trajectory.color);
-
+        material.set_shading_mode(ShadingMode::UNSHADED);
         // Commit to an ArrayMesh
         (surface_tool.commit().unwrap(), material)
     }


### PR DESCRIPTION
Makes the trajectories visible without any ambient light as in the case when a dark WorldEnvironment is set.