### PR TITLE
Fixed bug out of bounds error

### DIFF
--- a/godot/src/bodies/moon/moon.tscn
+++ b/godot/src/bodies/moon/moon.tscn
@@ -16,11 +16,6 @@ shader_parameter/occlusion_strength = 1.0
 shader_parameter/texture_scale = Vector2(0.02, 0.02)
 shader_parameter/texture_offset = Vector2(0, 0)
 
-[node name="Moon" type="Node3D"]
+[node name="Moon" type="GravityBody"]
 script = ExtResource("1_7s32x")
-Radius = 40
 MeshMaterial = SubResource("ShaderMaterial_b3avl")
-AmountOfCraters = 30
-MinCraterRadius = 2.0
-MaxCraterRadius = 5.0
-Smoothness = 1.0


### PR DESCRIPTION
Fixes the bug present in #97. 

This bug was caused by setting the radius value less than 1 which would cause the ```GenerateDataPoints``` function to not give any data points as it expects an integer. This in turn would mean that no mesh would be generated.

I fixed this by introducing a ```Resolution``` variable which is used for the ```GenerateDataPoints``` function now, so this will handle how detailed the sphere will be. The radius can now be set to any float value now which should solve the issue. 