### PR TITLE
Fix Editor Crashes

### DIFF
--- a/godot/src/bodies/planet/planet_theme/PlanetThemeGenerator.cs
+++ b/godot/src/bodies/planet/planet_theme/PlanetThemeGenerator.cs
@@ -34,7 +34,13 @@ public partial class PlanetThemeGenerator : Resource
     private Gradient gradient = new Gradient();
     private Vector3 atmosphereWavelengths;
 
-    public PlanetThemeGenerator() {
+    public PlanetThemeGenerator()
+    {
+        CallDeferred(nameof(Initialize));
+    }
+    private void Initialize()
+    {
+        // Called when the resource is initialized
         LoadThemeSets();
         GenerateTheme();
     }


### PR DESCRIPTION
Fixes #131 by making PlanetThemeGenerator initialization a deferred call.

There is till still a error message ```ERROR: Script class can only be set together with base class name``` that persists however it does not seem to causes any problems so a problem for our future selves. 